### PR TITLE
Extract property & valueURIs for a given attribute

### DIFF
--- a/R/extract_ea.R
+++ b/R/extract_ea.R
@@ -33,6 +33,10 @@ extract_ea <- function(paths, datetime = Sys.time()) {
           xml2::xml_text()
         attribute_unit <- xml2::xml_find_first(attribute, ".//unit/standardUnit | .//unit/customUnit") %>%
           xml2::xml_text()
+        attribute_propertyURI <- xml2::xml_find_first(attribute, "./annotation/propertyURI") %>% # added by SC
+          xml2::xml_text()
+        attribute_valueURI <- xml2::xml_find_first(attribute, "./annotation/valueURI") %>% # added by SC
+          xml2::xml_text()
 
         # Clean up xml_find results
         attribute_labels <- ifelse(nchar(attribute_labels) == 0, NA_character_, attribute_labels)
@@ -44,6 +48,8 @@ extract_ea <- function(paths, datetime = Sys.time()) {
                    attributeName = attribute_name,
                    attributeLabel = attribute_labels,
                    attributeDefinition = attribute_def,
+                   propertyURI = attribute_propertyURI,
+                   valueURI = attribute_valueURI,
                    attributeUnit = attribute_unit,
                    viewURL = paste0("https://search.dataone.org/view/", identifier))
       })

--- a/R/extract_ea.R
+++ b/R/extract_ea.R
@@ -48,9 +48,9 @@ extract_ea <- function(paths, datetime = Sys.time()) {
                    attributeName = attribute_name,
                    attributeLabel = attribute_labels,
                    attributeDefinition = attribute_def,
+                   attributeUnit = attribute_unit,
                    propertyURI = attribute_propertyURI,
                    valueURI = attribute_valueURI,
-                   attributeUnit = attribute_unit,
                    viewURL = paste0("https://search.dataone.org/view/", identifier))
       })
 


### PR DESCRIPTION
I made a super minor update to the `extract_ea()` function so that it also extracts/parses property & valueURIs associated with a given attribute. It's proven helpful as I'm beginning to explore the ADC datateam's progress on annotating attributes--hoping it might be useful for folks who are also interested in extracting semantic annotations.